### PR TITLE
Add asset dependency viewer HTML tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ Additional updates are planned.
 ### Run Query (Changelist Search)
 
 Simple changelist search feature
+
+### Asset Dependencies
+
+Displays metadata and recursive dependencies for a selected asset using Unreal's AssetRegistry.

--- a/src/asset-deps/asset_deps.py
+++ b/src/asset-deps/asset_deps.py
@@ -1,0 +1,40 @@
+import json
+import sys
+
+try:
+    import unreal
+except Exception:
+    unreal = None
+
+
+def get_dependencies(asset_path, visited=None):
+    if unreal is None:
+        return {"name": asset_path, "dependencies": []}
+
+    if visited is None:
+        visited = set()
+    if asset_path in visited:
+        return {"name": asset_path, "dependencies": []}
+    visited.add(asset_path)
+
+    registry = unreal.AssetRegistryHelpers.get_asset_registry()
+    opts = unreal.AssetRegistryDependencyOptions(include_soft_references=True,
+                                                 include_hard_references=True,
+                                                 include_searchable_names=False,
+                                                 include_management_references=False)
+    deps = registry.get_dependencies(asset_path, opts)
+    children = [get_dependencies(dep, visited) for dep in deps]
+    return {"name": asset_path, "dependencies": children}
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("{}".format(json.dumps({})))
+        return
+    asset = sys.argv[1]
+    tree = get_dependencies(asset)
+    print(json.dumps(tree))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/asset-deps/deps.js
+++ b/src/asset-deps/deps.js
@@ -1,0 +1,55 @@
+async function runOnload() {
+  let selectedFile = '';
+  try {
+    const sel = await p4vjs.getSelection();
+    if (sel && sel.files && sel.files.length > 0) {
+      selectedFile = sel.files[0];
+    }
+  } catch (e) {
+    // ignore if p4vjs is not available
+  }
+  if (selectedFile) {
+    document.getElementById('filePath').textContent = selectedFile;
+    await loadMeta(selectedFile);
+    await loadDeps(selectedFile);
+  }
+}
+
+async function loadMeta(file) {
+  try {
+    const result = await p4vjs.p4(`fstat "${file}"`);
+    document.getElementById('metadata').textContent = JSON.stringify(result.data, null, 2);
+  } catch (e) {
+    document.getElementById('metadata').textContent = 'Unable to load metadata';
+  }
+}
+
+async function loadDeps(file) {
+  try {
+    const resp = await fetch(`http://localhost:5000/deps?asset=${encodeURIComponent(file)}`);
+    const data = await resp.json();
+    const container = document.getElementById('depsContainer');
+    container.innerHTML = '';
+    const tree = buildTree(data);
+    const ul = document.createElement('ul');
+    ul.appendChild(tree);
+    container.appendChild(ul);
+  } catch (e) {
+    document.getElementById('depsContainer').textContent = 'Failed to load dependency data';
+  }
+}
+
+function buildTree(node) {
+  const li = document.createElement('li');
+  li.textContent = node.name || node.asset || node;
+  if (node.dependencies && node.dependencies.length > 0) {
+    const ul = document.createElement('ul');
+    node.dependencies.forEach(function (child) {
+      ul.appendChild(buildTree(child));
+    });
+    li.appendChild(ul);
+  }
+  return li;
+}
+
+window.addEventListener('load', runOnload, false);

--- a/src/asset-deps/index.html
+++ b/src/asset-deps/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Asset Dependencies</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css"
+    />
+    <script src="./deps.js"></script>
+  </head>
+  <body>
+    <section class="section">
+      <div class="box">
+        <h2 class="title is-4">Selected Asset</h2>
+        <p id="filePath"></p>
+        <pre id="metadata"></pre>
+      </div>
+      <div class="box">
+        <h2 class="title is-5">Dependencies</h2>
+        <div id="depsContainer">No data</div>
+      </div>
+    </section>
+  </body>
+</html>

--- a/src/index.html
+++ b/src/index.html
@@ -18,6 +18,11 @@
               <div class="box">Run Queries(Changelist Search)</div>
             </a>
           </div>
+          <div class="column is-6">
+            <a href="asset-deps">
+              <div class="box">Asset Dependencies</div>
+            </a>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Link asset dependency tool from main utilities index
- Build asset dependency tab that shows metadata and renders dependency tree
- Include Python script leveraging Unreal AssetRegistry to return dependencies
- Document asset dependency feature in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68b2d135a2948326ab70bd8e1c77257e