### PR TITLE
Add workspace dashboard with build and usage stats

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -18,6 +18,11 @@
               <div class="box">Run Queries(Changelist Search)</div>
             </a>
           </div>
+          <div class="column is-6">
+            <a href="workspace-dashboard">
+              <div class="box">Workspace Dashboard</div>
+            </a>
+          </div>
         </div>
       </div>
     </section>

--- a/src/workspace-dashboard/dashboard.js
+++ b/src/workspace-dashboard/dashboard.js
@@ -1,0 +1,123 @@
+var jenkinsUrl;
+
+async function loadDashboard() {
+  jenkinsUrl = window.localStorage.getItem('jenkinsUrl') || '';
+  if (jenkinsUrl) {
+    document.getElementById('jenkinsUrl').value = jenkinsUrl;
+  }
+  document.getElementById('saveJenkinsUrl').addEventListener('click', function () {
+    jenkinsUrl = document.getElementById('jenkinsUrl').value;
+    window.localStorage.setItem('jenkinsUrl', jenkinsUrl);
+    loadBuildStatus();
+  });
+
+  loadOpenFiles();
+  loadWorkspaceUsage();
+  loadBuildStatus();
+  setInterval(loadBuildStatus, 60000);
+}
+
+async function loadOpenFiles() {
+  try {
+    var result = await p4vjs.p4('opened -m 100');
+    var data = result.data || [];
+    var container = document.getElementById('openFiles');
+    if (data.length === 0) {
+      container.innerHTML = '<p>No opened files.</p>';
+      return;
+    }
+    var table = document.createElement('table');
+    table.classList.add('table', 'is-fullwidth', 'is-striped');
+    var tbody = document.createElement('tbody');
+    data.forEach(function (item) {
+      var tr = document.createElement('tr');
+      var td = document.createElement('td');
+      td.textContent = item.depotFile || item.clientFile || item.path;
+      tr.appendChild(td);
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    container.innerHTML = '';
+    container.appendChild(table);
+  } catch (e) {
+    document.getElementById('openFiles').innerHTML = 'Failed to load open files';
+  }
+}
+
+async function loadWorkspaceUsage() {
+  try {
+    var roots = await p4vjs.getDepotRoots();
+    var labels = [];
+    var sizes = [];
+    for (var i = 0; i < roots.length; i++) {
+      var root = roots[i];
+      try {
+        var res = await p4vjs.p4('sizes -s ' + root + '/...');
+        var size = 0;
+        if (res.data) {
+          res.data.forEach(function (d) {
+            if (d.fileSize) {
+              size += parseInt(d.fileSize, 10);
+            } else if (d.size) {
+              size += parseInt(d.size, 10);
+            }
+          });
+        }
+        labels.push(root);
+        sizes.push(size);
+      } catch (err) {
+        labels.push(root);
+        sizes.push(0);
+      }
+    }
+    var ctx = document.getElementById('workspaceChart').getContext('2d');
+    new Chart(ctx, {
+      type: 'pie',
+      data: {
+        labels: labels,
+        datasets: [
+          {
+            data: sizes,
+            backgroundColor: ['#f14668', '#209cee', '#23d160', '#ffdd57', '#00d1b2', '#ff851b', '#b86bff']
+          }
+        ]
+      },
+      options: {
+        plugins: {
+          legend: { position: 'bottom' }
+        }
+      }
+    });
+  } catch (e) {
+    document.getElementById('workspaceChart').replaceWith('Failed to load workspace usage');
+  }
+}
+
+async function loadBuildStatus() {
+  if (!jenkinsUrl) {
+    document.getElementById('buildStatus').innerHTML = 'Jenkins URL not configured';
+    return;
+  }
+  try {
+    var res = await fetch(jenkinsUrl);
+    if (!res.ok) {
+      document.getElementById('buildStatus').innerHTML = 'Failed to fetch build status';
+      return;
+    }
+    var data = await res.json();
+    var html = '';
+    html += '<p>Job: ' + (data.fullDisplayName || '') + '</p>';
+    html += '<p>Status: ' + (data.result || (data.building ? 'BUILDING' : 'UNKNOWN')) + '</p>';
+    if (data.timestamp) {
+      html += '<p>Time: ' + new Date(data.timestamp).toLocaleString() + '</p>';
+    }
+    if (data.changeSet && data.changeSet.items) {
+      html += '<p>Changes: ' + data.changeSet.items.length + '</p>';
+    }
+    document.getElementById('buildStatus').innerHTML = html;
+  } catch (e) {
+    document.getElementById('buildStatus').innerHTML = 'Error fetching build status';
+  }
+}
+
+window.addEventListener('load', loadDashboard, false);

--- a/src/workspace-dashboard/index.html
+++ b/src/workspace-dashboard/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Workspace Dashboard</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css" />
+    <link rel="stylesheet" href="../css/style.css" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="./dashboard.js"></script>
+  </head>
+  <body>
+    <section class="section">
+      <div class="container">
+        <h1 class="title">Workspace Dashboard</h1>
+        <div class="columns is-multiline">
+          <div class="column is-6">
+            <div class="box">
+              <h2 class="subtitle">Open Files</h2>
+              <div id="openFiles">Loading...</div>
+            </div>
+          </div>
+          <div class="column is-6">
+            <div class="box">
+              <h2 class="subtitle">Workspace Usage</h2>
+              <canvas id="workspaceChart"></canvas>
+            </div>
+          </div>
+          <div class="column is-6">
+            <div class="box">
+              <h2 class="subtitle">Latest Build</h2>
+              <div class="field has-addons">
+                <div class="control is-expanded">
+                  <input type="text" class="input" id="jenkinsUrl" placeholder="Jenkins API URL" />
+                </div>
+                <div class="control">
+                  <input type="submit" class="button is-info" id="saveJenkinsUrl" value="Save" />
+                </div>
+              </div>
+              <div id="buildStatus">Loading...</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add workspace-dashboard HTML/JS for open file list, workspace usage chart, and Jenkins build polling
- link workspace dashboard from main index

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68b2d13943148326b015707a75f53934